### PR TITLE
Remove `observe` in favor of `subscribe`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ pnpm add @rbxts/reflex
 
 ### 🎂 Producers
 
-**Producers** are the state containers that manage state updates and observe changes.
+**Producers** are the state containers that manage state updates and subscribe to changes.
 
 **`createProducer()`** takes an initial state and a table of action callbacks. Like Rodux, all state is immutable, so action callbacks should return a new state table if a change is needed.
 
@@ -88,12 +88,12 @@ const createSelectWord = (word: string) => {
 
 ### 🔮 Observing state
 
-You can observe changes to subsets of your state using the `observe`, `once`, and `wait` methods. Additionally, the `subscribe` method allows you to observe changes to the entire state.
+You can observe changes to subsets of your state using the `subscribe`, `once`, and `wait` methods. These methods take a selector and a callback, and call the callback whenever the selected state changes.
 
-Although dispatchers update state synchronously, observers are deferred until the next frame. This allows you to observe multiple state changes in a single frame.
+Although dispatchers update state synchronously, the events are deferred until the next frame. This allows you to observe multiple state changes in a single frame.
 
 ```ts
-const unsubscribe = myProducer.observe(selectCount, (count, prevCount) => {
+const unsubscribe = myProducer.subscribe(selectCount, (count, prevCount) => {
 	print(`Count changed from ${prevCount} to ${count}`);
 });
 
@@ -247,7 +247,7 @@ This project is still in early development, and is missing some features that I 
 
 ## 📖 Terminology
 
--   ♻️ **Producer**: A producer is a table that contains state observers and dispatchers.
+-   ♻️ **Producer**: A producer is a table that contains state events and dispatchers.
 
 -   🎂 **State**: An immutable table that represents the current state of the application.
 

--- a/src/combine-producers.spec.lua
+++ b/src/combine-producers.spec.lua
@@ -35,7 +35,6 @@ return function()
 			expect(combinedProducer.getDispatchers).to.be.a("function")
 			expect(combinedProducer.flush).to.be.a("function")
 			expect(combinedProducer.subscribe).to.be.a("function")
-			expect(combinedProducer.observe).to.be.a("function")
 			expect(combinedProducer.once).to.be.a("function")
 			expect(combinedProducer.wait).to.be.a("function")
 			expect(combinedProducer.select).to.be.a("function")
@@ -152,13 +151,13 @@ return function()
 		end)
 	end)
 
-	describe("CombinedProducer.observe", function()
-		it("should observe a selection of the combined producer", function()
+	describe("CombinedProducer.subscribe(selector)", function()
+		it("should subscribe to a selection of the combined producer", function()
 			local function selectPrivateCounterA(state)
 				return state.producerA.privateCounter
 			end
 
-			local unsubscribe = combinedProducer:observe(selectPrivateCounterA, function(privateCounterA)
+			local unsubscribe = combinedProducer:subscribe(selectPrivateCounterA, function(privateCounterA)
 				expect(privateCounterA).to.equal(3)
 			end)
 
@@ -174,7 +173,7 @@ return function()
 
 			local updated = false
 
-			local unsubscribe = combinedProducer:observe(selectPrivateCounterA, function(privateCounterA)
+			local unsubscribe = combinedProducer:subscribe(selectPrivateCounterA, function(privateCounterA)
 				updated = true
 			end)
 
@@ -192,7 +191,7 @@ return function()
 
 			local previousState = selectPrivateCounterA(combinedProducer:getState())
 
-			local unsubscribe = combinedProducer:observe(
+			local unsubscribe = combinedProducer:subscribe(
 				selectPrivateCounterA,
 				function(receivedCurrentState, receivedPreviousState)
 					expect(receivedPreviousState).to.equal(previousState)

--- a/src/create-producer.spec.lua
+++ b/src/create-producer.spec.lua
@@ -25,7 +25,6 @@ return function()
 			expect(producer.getDispatchers).to.be.a("function")
 			expect(producer.flush).to.be.a("function")
 			expect(producer.subscribe).to.be.a("function")
-			expect(producer.observe).to.be.a("function")
 			expect(producer.once).to.be.a("function")
 			expect(producer.wait).to.be.a("function")
 			expect(producer.select).to.be.a("function")
@@ -159,20 +158,20 @@ return function()
 		end)
 	end)
 
-	describe("Producer.observe", function()
+	describe("Producer.subscribe(selector)", function()
 		local selector = function(state)
 			return state.counter
 		end
 
 		it("should return an unsubscribe function", function()
-			local unsubscribe = producer:observe(selector, function() end)
+			local unsubscribe = producer:subscribe(selector, function() end)
 			expect(unsubscribe).to.be.a("function")
 			unsubscribe()
 		end)
 
 		it("should call the listener when the state changes", function()
 			local called = false
-			local unsubscribe = producer:observe(selector, function()
+			local unsubscribe = producer:subscribe(selector, function()
 				called = true
 			end)
 			producer.increment(1)
@@ -183,7 +182,7 @@ return function()
 
 		it("should not call the listener when a different part of the state changes", function()
 			local called = false
-			local unsubscribe = producer:observe(selector, function()
+			local unsubscribe = producer:subscribe(selector, function()
 				called = true
 			end)
 			producer.setSetter(1)
@@ -194,7 +193,7 @@ return function()
 
 		it("should pass the current and previous state", function()
 			local previousState = selector(producer:getState())
-			local unsubscribe = producer:observe(selector, function(receivedState, receivedPreviousState)
+			local unsubscribe = producer:subscribe(selector, function(receivedState, receivedPreviousState)
 				expect(receivedState).to.be.a("number")
 				expect(receivedPreviousState).to.be.a("number")
 				expect(receivedState).to.never.equal(receivedPreviousState)

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,6 @@ export type Producer<S, A> = InferDispatchersFromActions<A> & {
 	 * @returns A function that unsubscribes the callback.
 	 */
 	subscribe(callback: (state: S, prevState: S) => void): () => void;
-
 	/**
 	 * Subscribes to changes in a specific part of the state. The callback is
 	 * deferred from the frame that the state is changed.
@@ -49,7 +48,7 @@ export type Producer<S, A> = InferDispatchersFromActions<A> & {
 	 * @param callback The callback to call when the state changes.
 	 * @returns A function that unsubscribes the callback.
 	 */
-	observe<Selection>(
+	subscribe<Selection>(
 		selector: (state: S) => Selection,
 		callback: (state: Selection, prevState: Selection) => void,
 	): () => void;

--- a/test/src/example.server.ts
+++ b/test/src/example.server.ts
@@ -6,11 +6,11 @@ producer.subscribe((state) => {
 	print(`[example]: State changed to ${game.GetService("HttpService").JSONEncode(state)}`);
 });
 
-producer.observe(selectCount, (count, prevCount) => {
+producer.subscribe(selectCount, (count, prevCount) => {
 	print(`[example]: Count changed from ${prevCount} to ${count}`);
 });
 
-producer.observe(selectText, (text, prevText) => {
+producer.subscribe(selectText, (text, prevText) => {
 	print(`[example]: Text changed from "${prevText}" to "${text}"`);
 });
 


### PR DESCRIPTION
Resolves #2 

### 📚 Changes

- Include `observe` functionality as an overload of `subscribe`
- Replace references to `observe` with `subscribe`

### ✏️ Notes

- ⚠️ This is a breaking change! `observe` will be removed as a method of Producer.
- 🧪 All tests and benchmarks passed.