### PR TITLE
feat: add broadcaster filter options

### DIFF
--- a/docs/docs/advanced-guides/server-client-sync.md
+++ b/docs/docs/advanced-guides/server-client-sync.md
@@ -233,7 +233,7 @@ This sets up a broadcaster that sends shared actions to the clients when they're
 
 2.  `dispatch`: A user-defined callback that sends shared dispatched actions to the clients. It receives an array of actions and a player to send them to.
 
-3.  `hydrateRate`: The rate in seconds at which the server should send the latest state to the clients. The default is `5`, which means that every five seconds, every client passed to `start` will re-hydrate their store with the latest state.
+3.  `hydrateRate`: The rate in seconds at which the server should send the latest state to the clients. The default is `60`, which means that every minute, every client passed to `start` will re-hydrate their store with the latest state.
 
 It returns a broadcaster object, which has two properties:
 

--- a/docs/docs/advanced-guides/server-client-sync.md
+++ b/docs/docs/advanced-guides/server-client-sync.md
@@ -11,22 +11,21 @@ Reflex provides a quick way to sync the server's shared state with clients using
 
 :::note what you'll learn
 
--   🌎 What shared producer slices are
--   🔗 How to integrate shared slices into your state
--   🛰️ How to create broadcasters
--   📡 How to create receivers
+-   🌎 How to share state between the server and clients
+-   🛰️ How to create broadcasters and receivers
+-   🔒 Recipes for protecting data the client shouldn't have access to
 
 :::
 
 ---
 
-## Sync server state with clients
+## Sync state
 
 Reflex is designed to be used in any environment, on the client and the server. However, in game development, many cases come up where you need to send state from the server to clients. This is where the concept of **shared slices** comes in.
 
 ### Sharing state
 
-Shared slices are producers that are managed by the server and synced with clients. To create shared slices, we'll follow this project structure:
+Shared slices are producers that are managed by the server and synced with clients. To create shared slices, we'll follow this file hierarchy:
 
 ```
 shared
@@ -227,13 +226,15 @@ producer:applyMiddleware(broadcaster.middleware)
 
 This sets up a broadcaster that sends shared actions to the clients when they're dispatched. Once the middleware is applied, Reflex will begin syncing dispatched actions to the clients.
 
-[`createBroadcaster`](../reference/reflex/create-broadcaster) receives three options:
+[`createBroadcaster`](../reference/reflex/create-broadcaster) receives the following options:
 
 1.  `producers`: Your _shared slices_. This is used to determine which state and actions should be sent to the client.
 
 2.  `dispatch`: A user-defined callback that sends shared dispatched actions to the clients. It receives an array of actions and a player to send them to.
 
-3.  `hydrateRate`: The rate in seconds at which the server should send the latest state to the clients. The default is `60`, which means that every minute, every client passed to `start` will re-hydrate their store with the latest state.
+3.  `hydrateRate?`: The rate in seconds at which the server should send the latest state to the clients. The default is `60`, which means that every minute, every client passed to `start` will re-hydrate their store with the latest state.
+
+4.  [`beforeDispatch?`](#filtering-actions) and [`beforeHydrate?`](#filtering-state) for filtering state and actions before a client receives them.
 
 It returns a broadcaster object, which has two properties:
 
@@ -298,8 +299,116 @@ This code will call `start` when the middleware is applied, and hydrate the clie
 
 ---
 
+## Privacy
+
+### Filtering actions
+
+You can use the `beforeDispatch` option to filter or modify actions before they are sent to the client. This is useful if you have sensitive data you don't want to share between clients, or if you want to prevent certain actions from being dispatched to the client.
+
+This example will prevent the `sensitive` action from being dispatched to the client if the player's UserId is not the first argument:
+
+<Tabs groupId="languages">
+<TabItem value="TypeScript" default>
+
+```ts
+const broadcaster = createBroadcaster({
+	producers: slices,
+	dispatch: (player, actions) => {
+		remotes.dispatch.fire(player, actions);
+	},
+	beforeDispatch: (player, action) => {
+		// highlight-start
+		if (action.name === "sensitive" && action.arguments[0] !== player.UserId) {
+			return;
+		}
+		// highlight-end
+		return action;
+	},
+});
+```
+
+</TabItem>
+<TabItem value="Luau">
+
+```lua
+local broadcaster = Reflex.createBroadcaster({
+    producers = slices,
+    dispatch = function(player, actions)
+        remotes.dispatch:fire(player, actions)
+    end,
+    beforeDispatch = function(player, action)
+        // highlight-start
+        if action.name == "sensitive" and action.arguments[1] ~= player.UserId then
+            return
+        end
+        // highlight-end
+        return action
+    end,
+})
+```
+
+</TabItem>
+</Tabs>
+
+### Filtering state
+
+You can use the `beforeHydrate` option to filter or modify state before it is sent to the client. This is useful if you store sensitive data you don't want to share with clients.
+
+This example filters out all private data except for the current player's data:
+
+<Tabs groupId="languages">
+<TabItem value="TypeScript" default>
+
+```ts
+const broadcaster = createBroadcaster({
+	producers: slices,
+	dispatch: (player, actions) => {
+		remotes.dispatch.fire(player, actions);
+	},
+	beforeHydrate: (player, state) => {
+		return {
+			...state,
+			// highlight-start
+			private: {
+				[player.UserId]: state.private[player.UserId],
+			},
+			// highlight-end
+		};
+	},
+});
+```
+
+</TabItem>
+<TabItem value="Luau">
+
+```lua
+local broadcaster = Reflex.createBroadcaster({
+    producers = slices,
+    dispatch = function(player, actions)
+        remotes.dispatch:fire(player, actions)
+    end,
+    beforeHydrate = function(player, state)
+        local newState = table.clone(state)
+
+        // highlight-start
+        newState.private = {
+            [player.UserId] = state.private[player.UserId],
+        }
+        // highlight-end
+
+        return newState
+    end,
+})
+```
+
+</TabItem>
+</Tabs>
+
+---
+
 ## Summary
 
 -   Shared state is synced between the server and client using a broadcaster and a receiver.
 -   The **broadcaster** is responsible for sending state and actions to the receiver.
 -   The **receiver** is responsible for dispatching actions from the broadcaster.
+-   You can use the `beforeDispatch` and `beforeHydrate` options to filter actions and state before they are sent to the client.

--- a/docs/docs/reference/reflex/create-broadcaster.md
+++ b/docs/docs/reference/reflex/create-broadcaster.md
@@ -96,7 +96,7 @@ On the client, call [`createBroadcastReceiver`](create-broadcast-receiver) to re
 -   `options` - An object with options for the broadcaster.
     -   `producers` - A map of shared producers used to filter private actions and state from the root producer.
     -   `dispatch` - A function called when actions are ready to be sent to clients.
-    -   `hydrateRate` - The rate at which the entire shared state is sent to clients for hydration. Defaults to `5`.
+    -   `hydrateRate` - The rate at which the entire shared state is sent to clients for hydration. Defaults to `60`.
 
 #### Returns
 
@@ -388,7 +388,7 @@ This sets up a broadcaster that sends shared actions to the clients when they're
 
 1.  `producers`: Your _shared producer map_. This is used to determine which state and actions should be sent to the client.
 2.  `dispatch`: A user-defined callback that sends shared dispatched actions to the clients. It receives an array of actions and an array of players to send them to.
-3.  `hydrateRate`: The rate at which the server should send state to the clients for hydration. This is optional, and defaults to `5`.
+3.  `hydrateRate`: The rate at which the server should send state to the clients for hydration. This is optional, and defaults to `60`.
 
 It returns a broadcaster object, which has two properties:
 

--- a/docs/docs/reference/reflex/create-broadcaster.md
+++ b/docs/docs/reference/reflex/create-broadcaster.md
@@ -96,7 +96,7 @@ On the client, call [`createBroadcastReceiver`](create-broadcast-receiver) to re
 -   `options` - An object with options for the broadcaster.
     -   `producers` - A map of shared producers used to filter private actions and state from the root producer.
     -   `dispatch` - A function called when actions are ready to be sent to clients.
-    -   `hydrateRate` - The rate at which the entire shared state is sent to clients for hydration. Defaults to `60`.
+    -   `hydrateRate` - The rate at which the entire shared state is sent to clients for hydration. Defaults to `60`. Set to `-1` to disable periodic hydration.
 
 #### Returns
 

--- a/docs/docs/reference/reflex/create-broadcaster.md
+++ b/docs/docs/reference/reflex/create-broadcaster.md
@@ -96,7 +96,9 @@ On the client, call [`createBroadcastReceiver`](create-broadcast-receiver) to re
 -   `options` - An object with options for the broadcaster.
     -   `producers` - A map of shared producers used to filter private actions and state from the root producer.
     -   `dispatch` - A function called when actions are ready to be sent to clients.
-    -   `hydrateRate` - The rate at which the entire shared state is sent to clients for hydration. Defaults to `60`. Set to `-1` to disable periodic hydration.
+    -   `hydrateRate?` - The rate at which the entire shared state is sent to clients for re-hydration. Defaults to `60`. To disable this feature, set it to `-1`.
+    -   `beforeDispatch?` - Called before an action is dispatched to a client. Can be used to filter or modify actions before the client receives them.
+    -   `beforeHydrate?` - Called before the shared state is sent to a client for hydration. Can be used to filter or modify state.
 
 #### Returns
 
@@ -384,11 +386,12 @@ producer:applyMiddleware(broadcaster.middleware)
 
 This sets up a broadcaster that sends shared actions to the clients when they're dispatched. It also connects a `start` remote, which notifies the server that we are ready to receive actions and state.
 
-[`createBroadcaster`](#createbroadcasteroptions) receives three options:
+[`createBroadcaster`](#createbroadcasteroptions) receives the following options:
 
 1.  `producers`: Your _shared producer map_. This is used to determine which state and actions should be sent to the client.
 2.  `dispatch`: A user-defined callback that sends shared dispatched actions to the clients. It receives an array of actions and an array of players to send them to.
-3.  `hydrateRate`: The rate at which the server should send state to the clients for hydration. This is optional, and defaults to `60`.
+3.  `hydrateRate?`: The rate at which the server should send state to the clients for hydration. This is optional, and defaults to `60`.
+4.  `beforeDispatch?` and `beforeHydrate?` for filtering actions or state before they are sent to the client.
 
 It returns a broadcaster object, which has two properties:
 
@@ -403,6 +406,113 @@ It returns a broadcaster object, which has two properties:
 :::
 
 Now that you have your broadcaster set up, you can use [`createBroadcastReceiver`](create-broadcast-receiver) to dispatch actions from the server.
+
+---
+
+### Filtering actions
+
+You can use the `beforeDispatch` option to filter or modify actions before they are sent to the client. This is useful if you have sensitive data you don't want to share between clients, or if you want to prevent certain actions from being dispatched to the client.
+
+This example will prevent the `sensitive` action from being dispatched to the client if the player's UserId is not the first argument:
+
+<Tabs groupId="languages">
+<TabItem value="TypeScript" default>
+
+```ts
+const broadcaster = createBroadcaster({
+	producers: slices,
+	dispatch: (player, actions) => {
+		remotes.dispatch.fire(player, actions);
+	},
+	beforeDispatch: (player, action) => {
+		// highlight-start
+		if (action.name === "sensitive" && action.arguments[0] !== player.UserId) {
+			return;
+		}
+		// highlight-end
+		return action;
+	},
+});
+```
+
+</TabItem>
+<TabItem value="Luau">
+
+```lua
+local broadcaster = Reflex.createBroadcaster({
+    producers = slices,
+    dispatch = function(player, actions)
+        remotes.dispatch:fire(player, actions)
+    end,
+    beforeDispatch = function(player, action)
+        // highlight-start
+        if action.name == "sensitive" and action.arguments[1] ~= player.UserId then
+            return
+        end
+        // highlight-end
+        return action
+    end,
+})
+```
+
+</TabItem>
+</Tabs>
+
+---
+
+### Filtering state
+
+You can use the `beforeHydrate` option to filter or modify state before it is sent to the client. This is useful if you store sensitive data you don't want to share with clients.
+
+This example filters out all private data except for the current player's data:
+
+<Tabs groupId="languages">
+<TabItem value="TypeScript" default>
+
+```ts
+const broadcaster = createBroadcaster({
+	producers: slices,
+	dispatch: (player, actions) => {
+		remotes.dispatch.fire(player, actions);
+	},
+	beforeHydrate: (player, state) => {
+		return {
+			...state,
+			// highlight-start
+			private: {
+				[player.UserId]: state.private[player.UserId],
+			},
+			// highlight-end
+		};
+	},
+});
+```
+
+</TabItem>
+<TabItem value="Luau">
+
+```lua
+local broadcaster = Reflex.createBroadcaster({
+    producers = slices,
+    dispatch = function(player, actions)
+        remotes.dispatch:fire(player, actions)
+    end,
+    beforeHydrate = function(player, state)
+        local newState = table.clone(state)
+
+        // highlight-start
+        newState.private = {
+            [player.UserId] = state.private[player.UserId],
+        }
+        // highlight-end
+
+        return newState
+    end,
+})
+```
+
+</TabItem>
+</Tabs>
 
 ---
 

--- a/src/broadcast/createBroadcaster.lua
+++ b/src/broadcast/createBroadcaster.lua
@@ -103,7 +103,7 @@ local function createBroadcaster(options: types.BroadcasterOptions): types.Broad
 		for player in pendingActionsByPlayer do
 			hydratePlayer(player)
 		end
-	end, options.hydrateRate or 5)
+	end, options.hydrateRate or 60)
 
 	return broadcaster
 end

--- a/src/broadcast/hydrate.lua
+++ b/src/broadcast/hydrate.lua
@@ -9,7 +9,7 @@ local function createHydrateAction(state: any): types.BroadcastAction
 	}
 end
 
-local function consumeHydrateAction(actions: { types.BroadcastAction }): any
+local function consumeHydrateAction(actions: { types.BroadcastAction }): types.BroadcastAction?
 	local action = actions[1]
 
 	if action and action.name == HYDRATE then

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -566,18 +566,35 @@ export interface BroadcastAction {
  * Options for creating a broadcaster.
  * @server
  */
-export interface BroadcasterOptions<ProducerMap extends { [name: string]: Producer }> {
+export interface BroadcasterOptions<Producers extends ProducerMap> {
 	/**
 	 * The map of producers to broadcast.
 	 */
-	readonly producers: ProducerMap;
+	readonly producers: Producers;
 
 	/**
 	 * The rate at which the server should hydrate the clients
 	 * with the latest state.
-	 * @default 5
+	 * @default 60
 	 */
 	readonly hydrateRate?: number;
+
+	/**
+	 * Runs before actions are dispatched to a player. Can be used to
+	 * filter actions or manipulate them before sending.
+	 *
+	 * Return `undefined` to not share the action with this player.
+	 */
+	readonly beforeDispatch?: (player: Player, action: BroadcastAction) => BroadcastAction | undefined;
+
+	/**
+	 * Runs before the client is hydrated with the latest state. Can be
+	 * used to filter the state or hide certain values from the client.
+	 *
+	 * **Note:** Do not mutate the state in this function! Treat it as a
+	 * read-only object, and return a new object if you need to change it.
+	 */
+	readonly beforeHydrate?: (player: Player, state: CombineStates<Producers>) => Partial<CombineStates<Producers>>;
 
 	/**
 	 * A function that broadcasts actions to the given player.

--- a/src/types.lua
+++ b/src/types.lua
@@ -239,7 +239,7 @@ export type BroadcasterOptions = {
 	--[=[
 		The rate in seconds at which the server should hydrate the
 		clients with the latest state.
-		@default 5
+		@default 60
 	]=]
 	hydrateRate: number?,
 

--- a/src/types.lua
+++ b/src/types.lua
@@ -244,6 +244,25 @@ export type BroadcasterOptions = {
 	hydrateRate: number?,
 
 	--[=[
+		Runs before actions are dispatched to a player. Can be used to
+		filter actions or manipulate them before sending.
+
+		Avoid directly mutating the action. Instead, return a new action
+		if you need to change it. Return `nil` to not share the action
+		with this player.
+	]=]
+	beforeDispatch: ((player: Player, action: BroadcastAction) -> BroadcastAction?)?,
+
+	--[=[
+		Runs before the client is hydrated with the latest state. Can be
+		used to filter the state or hide certain values from the client.
+
+		Do not mutate the state in this function! Treat it as a read-only
+		object, and return a new object if you need to change it.
+	]=]
+	beforeHydrate: ((player: Player, state: { [string]: any }) -> { [string]: any })?,
+
+	--[=[
 		The function that will send the actions to the client.
 	]=]
 	dispatch: (player: Player, actions: { BroadcastAction }) -> (),

--- a/src/utils/setInterval.lua
+++ b/src/utils/setInterval.lua
@@ -1,6 +1,10 @@
 local RunService = game:GetService("RunService")
 
 local function setInterval(callback: () -> (), interval: number)
+	if interval < 0 then
+		return
+	end
+
 	local timer = 0
 	local connection
 


### PR DESCRIPTION
This PR introduces the `beforeDispatch` and `beforeHydrate` options for filtering out data before it is sent to a specific player.

It also increases the default hydrate interval to every 60 seconds.

```ts
beforeDispatch: (player, action) => {
  if (action.name === "sensitive" && action.arguments[0] !== player.UserId) {
    return;
  }
  return action;
},
```
```ts
beforeHydrate: (player, state) => {
  return {
    ...state,
    private: {
      [player.UserId]: state.private[player.UserId],
    },
  };
},
```