### PR TITLE
Fix BroadcastReceiverOptions and BroadcastAction types

### DIFF
--- a/src/types.lua
+++ b/src/types.lua
@@ -298,7 +298,7 @@ export type BroadcastReceiverOptions = {
 		A function that, when called, should fire a remote that calls
 		`start(player)` on the server broadcaster.
 	]=]
-	start: () -> any,
+	start: () -> (),
 }
 
 --[=[

--- a/src/types.lua
+++ b/src/types.lua
@@ -230,7 +230,7 @@ export type ProducerMap = { [string]: Producer }
 ]=]
 export type BroadcastAction = {
 	name: string,
-	arguments: {},
+	arguments: { any },
 }
 
 --[=[


### PR DESCRIPTION
`start` field goes from `() -> any` to `() -> ()`